### PR TITLE
PATRON FOR ALL

### DIFF
--- a/code/modules/client/preferences/_preferences.dm
+++ b/code/modules/client/preferences/_preferences.dm
@@ -1284,6 +1284,10 @@ GLOBAL_LIST_INIT(name_adjustments, list())
 						change_accent = TRUE
 					else
 						change_accent = FALSE
+					if(!patreon && !change_accent)
+						to_chat(user, "Sorry, this option is Patreon-exclusive or unavailable to your race.")
+						selected_accent = ACCENT_DEFAULT
+						return
 					var/accent
 					if(patreon)
 						accent = browser_input_list(user, "CHOOSE YOUR HERO'S ACCENT", "VOICE OF THE WORLD", GLOB.accent_list, selected_accent)

--- a/code/modules/client/preferences/_preferences.dm
+++ b/code/modules/client/preferences/_preferences.dm
@@ -238,9 +238,14 @@ GLOBAL_LIST_INIT(name_adjustments, list())
 	flavortext = null
 	headshot_link = null
 
+	// SHIFTING ROSES EDIT - PATRON FOR ALL
+	/*
 	// C/parent can be a client_interface
 	if(isclient(parent))
 		patreon = parent?.patreon?.has_access(ACCESS_ASSISTANT_RANK)
+	*/
+	patreon = TRUE // done here to avoid merge conflicts with the definition :)
+	// END SHIFTING ROSES EDIT
 
 	for(var/custom_name_id in GLOB.preferences_custom_names)
 		custom_names[custom_name_id] = get_default_name(custom_name_id)


### PR DESCRIPTION
gives everyone patron perks. this will fix accents and give everyone a nice 30 extra character slots. it also reverts the prior accent patreon PR because all that did was remove the warning that it didn't work

doing it this way reduces upstream merge conflicts compared to just ripping stuff out, and is less likely to break things.