### PR TITLE
Fix linters

### DIFF
--- a/_maps/map_files/vanderlin/vanderlin.dmm
+++ b/_maps/map_files/vanderlin/vanderlin.dmm
@@ -15869,7 +15869,7 @@
 	dir = 1
 	},
 /obj/structure/bars/bent,
-/turf/closed/basic,
+/turf/open/floor/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "jFE" = (
 /obj/structure/table/wood/large/corner{

--- a/code/modules/unit_tests/craftable_clothes.dm
+++ b/code/modules/unit_tests/craftable_clothes.dm
@@ -28,6 +28,7 @@ abstract types are automatically excluded.
 		/obj/item/clothing/head/helmet/skullcap/cult, // cultist item
 		/obj/item/clothing/head/helmet/leather/saiga, // idk what kind of recipe to make this
 		/obj/item/clothing/neck/mana_star, // todo?
+		/obj/item/clothing/head/helmet/pegasusknight, // todo?
 	)
 	// these don't use misc_flags = CRAFTING_TEST_EXCLUDE because we want to explicitly know which paths we are excluding.
 	/// excludes paths along with their subtypes


### PR DESCRIPTION
Contains all the CI/linter fixes not included in #45. Together they should make CI work, after which Herma should make it so that the completion gate check must pass before a PR can be merged.