### PR TITLE
Remove codeowners to avoid assign-users action failures

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,12 +6,4 @@
 
 # MAINTAINERS
 
-# aberrantQuesrist
-
-/icons/ @aberrantQuesrist
-/_maps/map_files/daftmarsh.dmm @aberrantQuesrist
-/_maps/map_files/vanderlin.dmm @aberrantQuesrist
-
-# Draggeru
-
-/_maps/* @Draggeru
+# todo: add Shifting Roses maintainers/spritetainers/maptainers


### PR DESCRIPTION
These are not members of the ShiftingRoses org and so it just caused the action to fail. This should eventually be updated with spritetainers/maptainers/maintainers/etc.